### PR TITLE
Write directly to output without staging

### DIFF
--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -371,7 +371,7 @@ class HadoopJobRunner(JobRunner):
         # replace output with a temporary work directory
         job_output_target = job.output()
         output_final = job_output_target.path
-        if hasattr(job, 'stage_output') and not job.stage_output:
+        if hasattr(job, 'enable_direct_output') and job.enable_direct_output:
             job_output_path = output_final
             tmp_target = None
         else:

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -371,7 +371,7 @@ class HadoopJobRunner(JobRunner):
         # replace output with a temporary work directory
         job_output_target = job.output()
         output_final = job_output_target.path
-        if hasattr(job_output_target, 'stage_output') and not job_output_target.stage_output:
+        if hasattr(job, 'stage_output') and not job.stage_output:
             job_output_path = output_final
             tmp_target = None
         else:
@@ -436,9 +436,6 @@ class HadoopJobRunner(JobRunner):
         arglist += ['-output', job_output_path]
 
         # submit job
-        if hasattr(job_output_target, 'prepare_for_output'):
-            job_output_target.prepare_for_output()
-
         create_packages_archive(packages, self.tmp_dir + '/packages.tar')
 
         job._dump(self.tmp_dir)

--- a/luigi/hadoop.py
+++ b/luigi/hadoop.py
@@ -369,9 +369,14 @@ class HadoopJobRunner(JobRunner):
         red_cmd = '{0} mrrunner.py reduce'.format(python_executable)
 
         # replace output with a temporary work directory
-        output_final = job.output().path
-        output_tmp_fn = output_final + '-temp-' + datetime.datetime.now().isoformat().replace(':', '-')
-        tmp_target = luigi.hdfs.HdfsTarget(output_tmp_fn, is_tmp=True)
+        job_output_target = job.output()
+        output_final = job_output_target.path
+        if hasattr(job_output_target, 'stage_output') and not job_output_target.stage_output:
+            job_output_path = output_final
+            tmp_target = None
+        else:
+            job_output_path = output_final + '-temp-' + datetime.datetime.now().isoformat().replace(':', '-')
+            tmp_target = luigi.hdfs.HdfsTarget(job_output_path, is_tmp=True)
 
         arglist = [luigi.hdfs.load_hadoop_cmd(), 'jar', self.streaming_jar]
 
@@ -428,9 +433,12 @@ class HadoopJobRunner(JobRunner):
             arglist += ['-input', target.path]
 
         assert isinstance(job.output(), luigi.hdfs.HdfsTarget)
-        arglist += ['-output', output_tmp_fn]
+        arglist += ['-output', job_output_path]
 
         # submit job
+        if hasattr(job_output_target, 'prepare_for_output'):
+            job_output_target.prepare_for_output()
+
         create_packages_archive(packages, self.tmp_dir + '/packages.tar')
 
         job._dump(self.tmp_dir)
@@ -438,7 +446,8 @@ class HadoopJobRunner(JobRunner):
         run_and_track_hadoop_job(arglist)
 
         # rename temporary work directory to given output
-        tmp_target.move(output_final, raise_if_exists=True)
+        if tmp_target:
+            tmp_target.move(output_final, raise_if_exists=True)
         self.finish()
 
     def finish(self):


### PR DESCRIPTION
This now respects the "stage_output" attribute on output targets. When false, this prevents Luigi from writing to a temporary directory and then performing a move. Instead it will just write the output directly to the output directory.

It also adds support for a "prerpare_for_output()" method on output targets that let them run whatever checks, perform cleanup etc right before the job is actually run.

@brianhw