### PR TITLE
pull in egg-info for any used package

### DIFF
--- a/test/hadoop_test.py
+++ b/test/hadoop_test.py
@@ -280,8 +280,7 @@ class CreatePackagesArchive(unittest.TestCase):
         add.assert_any_call('test/create_packages_archive_root/package/submodule_without_imports.py', 'package/submodule_without_imports.py')
         add.assert_any_call('test/create_packages_archive_root/package/subpackage/__init__.py', 'package/subpackage/__init__.py')
         add.assert_any_call('test/create_packages_archive_root/package/subpackage/submodule.py', 'package/subpackage/submodule.py')
-        add.assert_any_call('test/create_packages_archive_root/package.egg-info/top_level.txt', 'package.egg-info/top_level.txt')
-        assert add.call_count == 7
+        assert add.call_count == 6
 
     def _assert_package_subpackage(self, add):
         add.assert_any_call('test/create_packages_archive_root/package/__init__.py', 'package/__init__.py')


### PR DESCRIPTION
@brianhw this patch ensures that when a package or module is added to the tarball its associated egg-info directory is also included.

Given that the egg-info directory can have an arbitrary name that is not guaranteed to be related to the python package name, this is considerably more flexible than it was before.

FYI @HassanJaveed84 