### PR TITLE
Escapes '%' characters in task description and default values

### DIFF
--- a/luigi/interface.py
+++ b/luigi/interface.py
@@ -254,7 +254,10 @@ class ArgParseInterface(Interface):
             action = "store_true"
         else:
             action = "store"
-        parser.add_argument('--' + param_name.replace('_', '-'), help=' '.join(description), default=None, action=action)
+
+        # Escape any % characters that may be in the parameter name, description, or default values
+        escaped_description = ' '.join(description).replace(r'%', '%%')
+        parser.add_argument('--' + param_name.replace('_', '-'), help=escaped_description, default=None, action=action)
 
     @classmethod
     def add_task_parameters(cls, parser, task_cls):


### PR DESCRIPTION
Escapes '%' characters in task description and default values so that they can be passed through argparse during `--help` calls.

cf. https://github.com/edx/edx-analytics-pipeline/pull/274#discussion_r88524786

**Testing instructions**

1. Install [edx-analytics-pipeline branch `open-craft:jill/latest-problem-response`](https://github.com/open-craft/edx-analytics-pipeline/tree/jill/latest-problem-response).
1. Run `launch-task CourseBlocksApiDataTask --help` to see the task help fail with `ValueError: unsupported format character 'Y' (0x59) at index 219`.
2. Install this branch in the pipeline's virtualenv.
3. Run `launch-task CourseBlocksApiDataTask --help` again to see it succeed and print the  `--partition-format` description and default values.

*Reviewers*
- [x] @mulby 
- [x] @brianhw 